### PR TITLE
Optimized fastisqr, bug fix for mulsigned.

### DIFF
--- a/fastisqr.asm
+++ b/fastisqr.asm
@@ -1,5 +1,5 @@
 ; fast 16 bit isqrt by John Metcalf
-; 92 bytes, 344-379 cycles (average 362)
+; 89 bytes, 335-375 cycles (average 355.5)
 ; v2 - saved 3 cycles with a tweak suggested by Russ McNulty
 
 ; call with hl = number to square root

--- a/fastisqr.asm
+++ b/fastisqr.asm
@@ -5,79 +5,91 @@
 ; returns    a = square root
 ; corrupts hl, de
 
-  ld de,05040h
-  ld a,h
-  sub e
-  jr nc,sq7
-  add a,e
-  ld d,16
-sq7:
+; ----------
 
+  ld de,05040h  ; 10
+  ld a,h        ; 4
+  sub e         ; 4
+  jr nc,sq7     ;\
+  add a,e       ; | branch 1: 12cc
+  ld d,16       ; | branch 2: 18cc
+sq7:            ;/
 
-  cp d
-  jr c,sq6
-  sub d
-  set 5,d
-sq6:
-  res 4,d
-  srl d
+; ----------
 
-  set 2,d
-  cp d
-  jr c,sq5
-  sub d
-  set 3,d
-sq5:
-  srl d
+  cp d          ; 4
+  jr c,sq6      ;\
+  sub d         ; | branch 1: 12cc
+  set 5,d       ; | branch 2: 19cc
+sq6:            ;/
 
+; ----------
+  res 4,d       ; 8
+  srl d         ; 8
+  set 2,d       ; 8
+  cp d          ; 4
+  jr c,sq5      ;\
+  sub d         ; | branch 1: 12cc
+  set 3,d       ; | branch 2: 19cc
+sq5:            ;/
+  srl d         ; 8
 
-  inc a
-  sub d
-  jr nc,sq4
-  dec d
-  add a,d
-  dec d   ;this resets the low bit of D, so `srl d` resets carry.
-sq4:
+; ----------
 
-  srl d
-  ld h,a
+  inc a         ; 4
+  sub d         ; 4
+  jr nc,sq4     ;\
+  dec d         ; | branch 1: 12cc
+  add a,d       ; | branch 2: 19cc
+  dec d         ; | <-- this resets the low bit of D, so `srl d` resets carry.
+sq4:            ;/
+  srl d         ; 8
+  ld h,a        ; 4
 
+; ----------
 
-  sbc hl,de
-  ld a,e
-  jr nc,sq3
-  add hl,de
-sq3:
-  ccf
-  rra
-  srl d
-  rra
-  ld e,a
+  ld a,e        ; 4
+  sbc hl,de     ; 15
+  jr nc,sq3     ;\
+  add hl,de     ; | 12cc or 18cc
+sq3:            ;/
+  ccf           ; 4
+  rra           ; 4
+  srl d         ; 8
+  rra           ; 4
 
-  sbc hl,de
-  jr c,sq2
-  or 20h
-  db 254   ;start of `cp *` which is 7cc to skip the next byte.
-sq2:
-  add hl,de
-  xor 18h
-  srl d
-  rra
-  ld e,a
+; ----------
 
+  ld e,a        ; 4
+  sbc hl,de     ; 15
+  jr c,sq2      ;\
+  or 20h        ; | branch 1: 23cc
+  db 254        ; |   <-- start of `cp *` which is 7cc to skip the next byte.
+sq2:            ; | branch 2: 21cc
+  add hl,de     ;/
 
-  sbc hl,de
-  jr c,sq1
-  or 8
-  db 254   ;start of `cp *` which is 7cc to skip the next byte.
-sq1:
-  add hl,de
-  xor 6
-  srl d
-  rra
-  ld e,a
-  sbc hl,de
+  xor 18h       ; 7
+  srl d         ; 8
+  rra           ; 4
 
- sbc a,255
- srl d
- rra
+; ----------
+
+  ld e,a        ; 4
+  sbc hl,de     ; 15
+  jr c,sq1      ;\
+  or 8          ; | branch 1: 23cc
+  db 254        ; |   <-- start of `cp *` which is 7cc to skip the next byte.
+sq1:            ; | branch 2: 21cc
+  add hl,de     ;/
+
+  xor 6         ; 7
+  srl d         ; 8
+  rra           ; 4
+
+; ----------
+
+  ld e,a        ; 4
+  sbc hl,de     ; 15
+  sbc a,255     ; 7
+  srl d         ; 8
+  rra           ; 4

--- a/fastisqr.asm
+++ b/fastisqr.asm
@@ -51,14 +51,14 @@ sq4:
 
 ; ----------
 
+  xor a         ; 4
   add hl,de     ; 11
-  jr nc,sq3     ; 12 / 7
-  ld e,040h     ; 7
-  db 210        ; 10
-sq3:
+  jr c,sq3      ; 12 / 7
   sbc hl,de     ; 15
+sq3:
+  rra           ; 4
+  add a,e       ; 4
   sra d         ; 8
-  ld a,e        ; 4
   rra           ; 4
 
 ; ----------
@@ -89,12 +89,10 @@ sq1:
 
 ; ----------
 
-  inc a         ; 4
   ld e,a        ; 4
+  inc e         ; 4
   add hl,de     ; 11
-  jr nc,sq0     ; 12 / 7
-  and 0FDh      ; 7
-sq0:
+  sbc a,0       ; 7
   sra d         ; 8
   rra           ; 4
   cpl           ; 4

--- a/mulsigned.asm
+++ b/mulsigned.asm
@@ -1,5 +1,8 @@
 ; 16 bit signed multiply by John Metcalf
-; 32 bytes, average approx ~1090 cycles
+;31 bytes
+;min: 928cc
+;max: 1257cc
+;avg: 1088.5cc
 
 ; call with bc, de = 16 bit signed numbers to multiply
 ; returns   de:hl = 32 bit signed product
@@ -15,13 +18,13 @@ multiply:
   jr z,muldpos
   sbc hl,bc
 muldpos:
-  ld a,b
-  sra a
-  and 0C0h
-  add a,d
-  ld d,a
 
-  ld a,16
+  or b
+  jp p,mulbpos
+  sbc hl,bc
+mulbpos:
+
+ld a,16
 mulloop:
   add hl,hl
   rl e

--- a/mulsigned.asm
+++ b/mulsigned.asm
@@ -21,7 +21,7 @@ muldpos:
 
   or b
   jp p,mulbpos
-  sbc hl,bc
+  sbc hl,de
 mulbpos:
 
 ld a,16


### PR DESCRIPTION
I found two optimizations, saving 3 bytes in all, and 4cc to 9cc, with an average saving of 6.5cc.